### PR TITLE
doc: do not begin yaml value with backtick

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -575,7 +575,8 @@ changes:
     description: The `lookup` option is supported.
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/13623
-    description: `recvBufferSize` and `sendBufferSize` options are supported now.
+    description: The `recvBufferSize` and `sendBufferSize` options are
+                 supported now.
 -->
 
 * `options` {Object} Available options are:


### PR DESCRIPTION
Will break YAML parsing!

See details in the PR.

PR-URL: https://github.com/nodejs/node/pull/15447
Fixes: https://github.com/nodejs/node/issues/14930
Reviewed-By: Refael Ackermann <refack@gmail.com>
Reviewed-By: Anna Henningsen <anna@addaleax.net>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
