### PR TITLE
Update upstream src: minor c++ refactors to module_wrap

### DIFF
--- a/src/env.h
+++ b/src/env.h
@@ -52,6 +52,10 @@ namespace performance {
 struct performance_state;
 }
 
+namespace loader {
+class ModuleWrap;
+}
+
 // Pick an index that's hopefully out of the way when we're embedded inside
 // another application. Performance-wise or memory-wise it doesn't matter:
 // Context::SetAlignedPointerInEmbedderData() is backed by a FixedArray,
@@ -584,6 +588,8 @@ class Environment {
 
   // List of id's that have been destroyed and need the destroy() cb called.
   inline std::vector<double>* destroy_ids_list();
+
+  std::unordered_multimap<int, loader::ModuleWrap*> module_map;
 
   inline double* heap_statistics_buffer() const;
   inline void set_heap_statistics_buffer(double* pointer);

--- a/src/module_wrap.h
+++ b/src/module_wrap.h
@@ -3,7 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include <map>
+#include <unordered_map>
 #include <string>
 #include <vector>
 #include "node_url.h"
@@ -45,9 +45,7 @@ class ModuleWrap : public BaseObject {
   v8::Persistent<v8::Module> module_;
   v8::Persistent<v8::String> url_;
   bool linked_ = false;
-  std::map<std::string, v8::Persistent<v8::Promise>*> resolve_cache_;
-
-  static std::map<int, std::vector<ModuleWrap*>*> module_map_;
+  std::unordered_map<std::string, v8::Persistent<v8::Promise>> resolve_cache_;
 };
 
 }  // namespace loader


### PR DESCRIPTION
- Move `module_map` to `Environment` instead of having it be global
  state
- `std::map` → `std::unordered_map`
- Remove one level of indirection for the map values
- Clean up empty vectors in `module_map`
- Call `Reset()` on all persistent handles in `resolve_cache_`
- Add a missing `HandleScope` to `ModuleWrap::~ModuleWrap()`

PR-URL: https://github.com/nodejs/node/pull/15515
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Bradley Farias <bradley.meck@gmail.com>
Reviewed-By: Timothy Gu <timothygu99@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
