### PR TITLE
Stabilize min_const_unsafe_fn

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -155,7 +155,12 @@ function startup() {
     return;
   }
 
-  if (isMainThread) {
+  // If the process is spawned with env NODE_CHANNEL_FD, it's probably
+  // spawned by our child_process module, then initialize IPC.
+  // This attaches some internal event listeners and creates:
+  // process.send(), process.channel, process.connected,
+  // process.disconnect()
+  if (isMainThread && process.env.NODE_CHANNEL_FD) {
     mainThreadSetup.setupChildProcessIpcChannel();
   }
 

--- a/lib/internal/process/main_thread_only.js
+++ b/lib/internal/process/main_thread_only.js
@@ -21,8 +21,6 @@ const {
   getMainThreadStdio
 } = require('internal/process/stdio');
 
-const assert = require('assert').strict;
-
 function setupStdio() {
   setupProcessStdio(getMainThreadStdio());
 }
@@ -163,18 +161,16 @@ function setupSignalHandlers(internalBinding) {
 }
 
 function setupChildProcessIpcChannel() {
-  // If we were spawned with env NODE_CHANNEL_FD then load that up and
-  // start parsing data from that stream.
-  if (process.env.NODE_CHANNEL_FD) {
-    const fd = parseInt(process.env.NODE_CHANNEL_FD, 10);
-    assert(fd >= 0);
+  const assert = require('assert').strict;
 
-    // Make sure it's not accidentally inherited by child processes.
-    delete process.env.NODE_CHANNEL_FD;
+  const fd = parseInt(process.env.NODE_CHANNEL_FD, 10);
+  assert(fd >= 0);
 
-    require('child_process')._forkChild(fd);
-    assert(process.send);
-  }
+  // Make sure it's not accidentally inherited by child processes.
+  delete process.env.NODE_CHANNEL_FD;
+
+  require('child_process')._forkChild(fd);
+  assert(process.send);
 }
 
 module.exports = {


### PR DESCRIPTION
Instead of branching in main_thread_only.js, move the branch on
process.env.NODE_CHANNEL_FD in node.js so it's easier to tell when
this needs to happen. Also added comments about what side effect
this causes, and lazy load `assert`.

PR-URL: https://github.com/nodejs/node/pull/25130
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: James M Snell <jasnell@gmail.com>
Reviewed-By: Jeremiah Senkpiel <fishrock123@rocketmail.com>
Reviewed-By: Ruben Bridgewater <ruben@bridgewater.de>
Reviewed-By: Luigi Pinca <luigipinca@gmail.com>

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
